### PR TITLE
Add repository guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Repository Guidelines
+
+## Coding style
+- Format all Python files using `black` with the line length specified in `pyproject.toml` (88 characters).
+
+## Testing
+- Install dependencies listed in `requirements.txt` when needed.
+- Run the unit tests using `pytest tests/unit/pairwisetest.py -q` before committing.
+
+## Commit messages
+- Keep commit summaries short (under 72 characters) and use the imperative mood.
+
+## Documentation
+- Update docstrings or `README.md` when you modify or add public APIs.

--- a/bayesify/pairwise.py
+++ b/bayesify/pairwise.py
@@ -769,13 +769,13 @@ class PyroMCMCRegressor:
         base = numpyro.sample(
             "base",
             # dist.Normal(0, 1)  # dist.Normal(self.prior_root_mean, self.prior_root_std)
-            base_prior
+            base_prior,
             # "base",
             # base_prior,
         )
         rnd_influences = numpyro.sample(
             "coefs",
-            infl_prior
+            infl_prior,
             # dist.Normal(jnp.zeros(data.shape[1]), jnp.ones(data.shape[1]))
             # dist.Normal(
             #     self.prior_coef_means,
@@ -922,8 +922,8 @@ class PyroMCMCRegressor:
 
         base_prior = dist.Normal(jnp.array(root_mean), jnp.array(root_std))
         # OLD VERSION WITHOUT 1/ err_mean
-        #error_prior = dist.Exponential(jnp.array(err_mean))
-        error_prior = dist.Exponential(1/jnp.array(err_mean))
+        # error_prior = dist.Exponential(jnp.array(err_mean))
+        error_prior = dist.Exponential(1 / jnp.array(err_mean))
         coef_prior = dist.Normal(
             jnp.array(means_weighted),
             jnp.array(stds_weighted),


### PR DESCRIPTION
## Summary
- add an AGENTS file with instructions for contributors
- apply black formatting to `pairwise.py`

## Testing
- `black .`
- `pytest tests/unit/pairwisetest.py -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*


------
https://chatgpt.com/codex/tasks/task_e_687fd26f802883309a1ff2dcd0cd0864