### PR TITLE
Fix coefficient parsing bug

### DIFF
--- a/bayesify/datahandler.py
+++ b/bayesify/datahandler.py
@@ -577,5 +577,5 @@ class DistBasedRepo(ConfigSysProxy):
         for term in terms:
             term_comps = term.split(" * ")
             coeff, ft = term_comps[0], tuple(term_comps[1:])
-            coeff_map[ft] = coeff_map
+            coeff_map[ft] = float(coeff)
         return coeff_map


### PR DESCRIPTION
## Summary
- ensure parse_coeffs stores each term's coefficient value

## Testing
- `pytest tests/unit/pairwisetest.py -q` *(fails: ModuleNotFoundError: No module named 'seaborn')*

------
https://chatgpt.com/codex/tasks/task_e_687fd5039b20833089effcae94d2e570