### PR TITLE
Fix duplicate method in pairwise.py

### DIFF
--- a/bayesify/pairwise.py
+++ b/bayesify/pairwise.py
@@ -361,19 +361,6 @@ class P4Preprocessing(TransformerMixin, BaseEstimator):
         pred = self.top_candidate_lr.predict(X_)
         return pred
 
-    def transform_data_to_candidate_features(self, candidate, train_x):
-        mapped_features = []
-        for term in candidate:
-            idx = [self.pos_map[ft] for ft in term]
-            selected_cols = np.array(train_x)[:, idx]
-            if len(idx) > 1:
-                mapped_feature = np.product(selected_cols, axis=1).ravel()
-            else:
-                mapped_feature = selected_cols.ravel()
-            mapped_features.append(list(mapped_feature))
-        reshaped_mapped_x = np.atleast_2d(mapped_features).T
-        return reshaped_mapped_x
-
     def fit_and_eval_lin_reg(self, lin_reg_features, reg_proto=None, verbose=True):
         if not reg_proto:
             reg_proto = Ridge()


### PR DESCRIPTION
## Summary
- remove second transform_data_to_candidate_features implementation

## Testing
- `pytest tests/unit/pairwisetest.py -q` *(fails: AttributeError: module 'matplotlib.cm' has no attribute 'register_cmap')*

------
https://chatgpt.com/codex/tasks/task_e_687fd58afad083309ae7d197b9570e26